### PR TITLE
Add instant and prefix-based completion (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ To explicitly convert (or convert back) use commands **UnicodeMath: Convert**, *
 
 To select symbols from list, use command **UnicodeMath: Insert**
 
+Instant conversion
+------------------
+
+Instant conversion allows eager conversion of symbols in the following situations:
+
+1. When `\name` is typed, there is a symbol called `name`, and no other symbol starts with `name`;
+2. When `\nameX` is typed (for `X` any character), there is a symbol called `name`, but none that starts with `nameX`.
+
+The intent is to remove control keystrokes and get the same result as when typing LaTeX code; for instance typing `\delta \subseteq \pi(f)` with instant conversion enabled will input `δ ⊆ π(f)`.
+
+When using instant conversion it is recommended to disable `accept_prefixes`. `convert_on_space` can also be disabled to make a space after a symbol name use case 2 above instead of activating the conversion command.
+
 Settings
 --------
 
@@ -113,6 +125,18 @@ Enable (default) or disable converting list of chars with prefix:
 
 <pre>
 	"convert_list": true
+</pre>
+
+Enable or disable (default) instant conversion:
+
+<pre>
+	"convert_instantly": true
+</pre>
+
+Enable or disable (default) treating a non-ambiguous prefix of a symbol name as the full name:
+
+<pre>
+	"accept_prefixes": true
 </pre>
 
 Font settings

--- a/UnicodeMath.sublime-settings
+++ b/UnicodeMath.sublime-settings
@@ -22,5 +22,9 @@
     "convert_sub_super": true,
     // List-convert, \\prefix\abc → \prefixa\prefixb\prefixc, for example
     // \\Bbb\ABC → \BbbA\BbbB\BbbC → 𝔸𝔹ℂ
-    "convert_list": true
+    "convert_list": true,
+    // Convert instantly when an escape is complete, without pressing space
+    "convert_instantly": false,
+    // Treat a non-ambiguous prefix as a full symbol name
+    "accept_prefixes": false,
 }


### PR DESCRIPTION
This PR implements a rough version of the features proposed in the linked issue.

- The prefix feature is supported by adding a `symbol_by_unique_prefix()` function in `mathsymbols.py`. The function only searches for 2 matching prefixes, and is used both in `can_replace()` and the replacement function.
- The instant conversion feature is supported by using a text change listener. Apparently that listener is designed for replaying changes (and is quite recent), so I might be hacking a bit. But the view listener only gives `on_modified()` and that doesn't allow me to disable conversion during undos; the commented view-listener version would just run instantly after undoing a conversion and redo it again.

Not sure if this is fine to merge yet (I'm a bit worried about the text change listener), but at least it's out there. :smile: 