### PR TITLE
Add option to add a trailing space when options are accepted with a space

### DIFF
--- a/UnicodeMath.sublime-settings
+++ b/UnicodeMath.sublime-settings
@@ -27,4 +27,6 @@
     "convert_instantly": false,
     // Treat a non-ambiguous prefix as a full symbol name
     "accept_prefixes": false,
+    // Insert a trailing space after symbol insertation
+    "trailing_space": false,
 }

--- a/UnicodeMath.sublime-settings
+++ b/UnicodeMath.sublime-settings
@@ -27,6 +27,6 @@
     "convert_instantly": false,
     // Treat a non-ambiguous prefix as a full symbol name
     "accept_prefixes": false,
-    // Insert a trailing space after symbol insertation
+    // Insert a trailing space after symbol insertion
     "trailing_space": false,
 }

--- a/unicodecomplete.py
+++ b/unicodecomplete.py
@@ -207,6 +207,8 @@ class UnicodeMathConvert(sublime_plugin.TextCommand):
         if m:
             rep = replacement(m, instant)
             if rep is not None:
+                if enabled('trailing_space'):
+                    rep += " "
                 self.view.replace(edit, sublime.Region(r.begin() - (m.end() - m.start()), r.begin()), rep)
 
     def convert_selection(self, edit, r, instant):


### PR DESCRIPTION
I've got this patch running locally and thought it might be helpful. I like typing out the full names of symbols without stopping to check I've got the right symbol for tab-complete when transcribing things: and I have a lot of muscle memory for basic LaTeX entry, where I don't need to press space twice. 

This adds an option (disabled by default) to add a trailing space after a symbol has been inserted with the space key (not tab key).